### PR TITLE
Merge to add the withCredentials: true to the $http request

### DIFF
--- a/with-lineman/app/js/bootstrap.js
+++ b/with-lineman/app/js/bootstrap.js
@@ -4,11 +4,16 @@
 
   $injector.invoke(function($http, $rootScope) {
     // this works!
+    // Need to ADD the withCredentials otherwise Laravel will create a new session on each page reload.
     $rootScope.$apply(function() {
-      $http.get("/auth/csrf_token").then(function(response) {
-        angular.module("app").constant("CSRF_TOKEN", response.csrf_token);
-        angular.bootstrap(document, ['app']);
-      });
+      $http({withCredentials: true,
+            method: "GET",
+            url: "/auth/csrf_token"
+            })
+            .then(function(response) {
+              angular.module("app").constant("CSRF_TOKEN", response.csrf_token);
+              angular.bootstrap(document, ['app']);
+            });
     });
   });
 


### PR DESCRIPTION
Hi,
When using the bootstrap.js alone (without Lineman) on top of our services.js you will end up with token missmatch exceptions all the time. Not too sure if this is linked to your ngix comment but regardless I found a patch to it. When using the $http you need to make sure to use the withCredentials: true
